### PR TITLE
Fix: Prevent table overflow in PDF templates

### DIFF
--- a/frontend/src/components/invoice-templates/ClassicInviocePDF.tsx
+++ b/frontend/src/components/invoice-templates/ClassicInviocePDF.tsx
@@ -287,7 +287,7 @@ const ClassicInvoicePDF: React.FC<{ invoiceData: InvoiceData, qrCode: string }> 
                         ) : ''}
                     </View>
                     {/* Items Table */}
-                    <View style={[styles.table, { marginBottom: 32 }]}>
+                    <View style={[styles.table, { marginBottom: 32 }]} minPresenceAhead={25}>
                         {/* Table Header */}
                         <View style={styles.tableHeader} wrap={false}>
                             <Text style={[styles.tableHeaderCell, { flex: 2 }]}>Item</Text>

--- a/frontend/src/components/invoice-templates/MinimalInvoicePDF.tsx
+++ b/frontend/src/components/invoice-templates/MinimalInvoicePDF.tsx
@@ -249,10 +249,12 @@ const MinimalInvoicePDF: React.FC<{ invoiceData: InvoiceData, qrCode: string }> 
                         <Text style={styles.invoiceNumber}>Date: {invoiceDate}</Text>
                     </View>
                 </View>
-                {/* Bill To & Ship To */}
-                <View style={styles.billToSection}>
-                    <View style={styles.billTo}>
-                        <Text style={styles.cardTitle}>Bill To:</Text>
+                {/* Main Content Wrapper */}
+                <View style={{ marginBottom: 72 }}>
+                    {/* Bill To & Ship To */}
+                    <View style={styles.billToSection}>
+                        <View style={styles.billTo}>
+                            <Text style={styles.cardTitle}>Bill To:</Text>
                         <Text style={styles.cardField}><Text style={{ fontWeight: 'bold' }}>Name:</Text> {customerBillTo.name}</Text>
                         {customerBillTo.address && <Text style={styles.cardField}><Text style={{ fontWeight: 'bold' }}>Address:</Text> {customerBillTo.address}</Text>}
                         {customerBillTo.gstNumber && <Text style={styles.cardField}><Text style={{ fontWeight: 'bold' }}>GST Number:</Text> {customerBillTo.gstNumber}</Text>}
@@ -269,7 +271,7 @@ const MinimalInvoicePDF: React.FC<{ invoiceData: InvoiceData, qrCode: string }> 
                     ) : ''}
                 </View>
                 {/* Items Table */}
-                <View style={[styles.table, { marginBottom: 32 }]}>
+                <View style={styles.table}>
                     {/* Table Header */}
                     <View style={styles.tableHeader} wrap={false}>
                         <Text style={[styles.tableHeaderCell, { flex: 2 }]}>Item</Text>
@@ -337,6 +339,8 @@ const MinimalInvoicePDF: React.FC<{ invoiceData: InvoiceData, qrCode: string }> 
                     <Text style={{ fontSize: 11, marginBottom: 2 }}>- We declare that this invoice shows the actual price of the goods described and that all particulars are true and correct.</Text>
                     <Text style={{ fontSize: 11 }}>- Payment is due within 30 days of the invoice date.</Text>
                 </View>
+                </View>
+                {/* End of Main Content Wrapper */}
                 {/* Classic UI Footer with border, background, and spaced info */}
                 <View
                     style={{


### PR DESCRIPTION
Addresses an issue in the Minimal and Classic PDF templates where the products table could unnecessarily move to the next page or break awkwardly.

Modifications:

1.  **MinimalInvoicePDF.tsx**: I wrapped the main content sections (including the items table, billing info, summary, and terms) in a parent `<View>`. I applied a `marginBottom: 72` to this wrapper. This reserves space for the fixed footer, improving the PDF rendering engine's page break decisions and preventing content-footer overlap.

2.  **ClassicInviocePDF.tsx**: I added the `minPresenceAhead={25}` prop to the main `<View>` component representing the items table. This encourages the renderer to keep at least a small part of the table (approx. one row height) on the current page if it starts rendering there, preventing scenarios where the table header might be orphaned or only a tiny fraction of the table appears before a page break. This template already had a bottom margin for the footer.

These changes ensure that the tables in both templates handle page breaks more gracefully, making better use of available page space and avoiding awkward breaks.